### PR TITLE
Support for address extensions

### DIFF
--- a/bin/dspam-milter.cfg
+++ b/bin/dspam-milter.cfg
@@ -120,3 +120,12 @@
 #
 # Default:
 # accept_classes = Innocent,Whitelisted
+
+# recipient_delimiter
+# Some MTAs (eg. Postfix) handle addresses in the form of user+extension.
+# This option specifies which characters separate the user from the
+# address extionsion part.
+# This is a companion to dspam's EnablePlusedDetail configuration option.
+#
+# Default:
+# recipient_delimiter = +


### PR DESCRIPTION
Strip address extensions from recipients before sending the mail to
dspam. This adds a configuration option to specify the
recipient_delimiter in use.

Please tell me if you think something should be done differently.
