### PR TITLE
Search for accepted recipients case-insensitively

### DIFF
--- a/dspam/client.py
+++ b/dspam/client.py
@@ -401,8 +401,20 @@ class DspamClient(object):
                 try:
                     self._recipients.remove(rcpt)
                 except ValueError:
-                    raise DspamClientError(
-                        'Message was accepted for unknown recipient ' + rcpt)
+                    # It might be that the accepted recipient *is* in the list,
+                    # but has a different case. Let's look for that
+                    for r in self._recipients:
+                        if r.lower() == rcpt.lower():
+                            try:
+                                self._recipients.remove(r)
+                            except ValueError:
+                                raise DspamClientError(
+                                    'Message was accepted for unknown recipient ' + rcpt)
+                            break
+                    else:
+                        # Fell off the end of the loop without finding a match
+                        raise DspamClientError(
+                            'Message was accepted for unknown recipient ' + rcpt)
                 self.results[rcpt] = {'accepted': True}
                 logger.debug(
                     'Message accepted for recipient {} in LMTP mode'.format(


### PR DESCRIPTION
If dspam accepts a message for a recipient, but the message specified the recipient in a different case (for example a message for `BOB@example.com` gets accepted for `bob@example.com`), then an error is currently raised.

Instead, walk the recipient list, looking for a case-insensitive match first.
