### PR TITLE
Fix minor issue in `test_connect` during test teardown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 before_install:
   - "sudo apt-get update -qq"
 install: 
-  - "pip install --use-mirrors pytest-cov pytest-pep8 flexmock"
+  - "pip install pytest-cov pytest-pep8 flexmock"
   - "sudo apt-get install -qq python-docutils libmilter-dev"
 script: 
   - "python setup.py test"

--- a/dspam/client_test.py
+++ b/dspam/client_test.py
@@ -50,16 +50,17 @@ def test_read():
 
 
 def test_connect(monkeypatch):
-    def mp_socket_connect(self, address):
-        # succeed without creating a connection
+    def noop(*args, **kwargs):
         pass
-    monkeypatch.setattr(socket.socket, 'connect', mp_socket_connect)
+    monkeypatch.setattr(socket.socket, 'connect', noop)
 
     c = DspamClient()
     flexmock(c).should_receive('_read').once().and_return(
         '220 DSPAM DLMTP 3.10.2 Authentication Required')
     c.connect()
     assert isinstance(c._socket, socket.socket)
+    # reset the socket to prevent 'Broken pipe' errors during test teardown invoked by DspamClient.quit()
+    c._socket = None
 
 
 def test_connect_unix_failed(tmpdir):


### PR DESCRIPTION
The gc of the DspamClient invoked the quit() method, which tried
to write to a socket that was not connected to anything writable.

Full error: `Exception socket.error: (32, 'Broken pipe') in <bound method DspamClient.__del__ of <dspam.client.DspamClient object at 0x7f941a08af50>> ignored`